### PR TITLE
Corrected a typo in `init` output

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -16,7 +16,7 @@ program
     var projectPath = nodePath.resolve(path || process.cwd())
 
     var done = function(err){
-      console.log('initializd project at', projectPath)
+      console.log('initialized project at', projectPath)
     }
 
     if(path){


### PR DESCRIPTION
Output on successful init said "initializd project at <path>".

Updated to say "initialized project at <path>"
