### PR TITLE
500 error instead of error view in 0.8.4

### DIFF
--- a/lib/templates/_layout.jade
+++ b/lib/templates/_layout.jade
@@ -3,7 +3,8 @@ html(lang="en")
 	head
 		meta(charset="utf-8")
 		meta(http-equiv="X-UA-Compatible", content="IE=edge,chrome=1")
-		title #{ pkg.name } #{ pkg.version }
+		//- title #{ pkg.name } #{ pkg.version }
+		title Harp
 		meta(name="handheldfriendly", content="true")
 		meta(name="mobileoptimized", content="320")
 		meta(name="viewport", content="width=device-width, initial-scale=1.0")


### PR DESCRIPTION
`pkg` variables in `_layout.jade` are preventing the errors from showing as of 0.8.4.
