### PR TITLE
Length -> Buffer Length, fix for file contains Chinese chars.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -276,8 +276,8 @@ exports.process = function(req, rsp, next){
       var charset    = mime.charsets.lookup(mimeType)
       rsp.statusCode = 200
       rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
-      rsp.setHeader('Content-Length', body.length)
-      rsp.end(body)
+      rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
+      rsp.end(body);
     }
   })
 


### PR DESCRIPTION
Content-Type will be wrong if body has special chars such as Chinese.

http://stackoverflow.com/questions/3905473/node-js-cuts-off-files-when-serving-over-https
