### PR TITLE
Fixes GH-21: Open server URL from terminal

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -90,7 +90,7 @@ program
     var projectPath = nodePath.resolve(process.cwd(), path || "")
     var port        = program.port || 9000
     harp.server(projectPath, { port: port }, function(){
-      output("Your server is listening at http://localhost:" + port + "...")
+      output("Your server is listening at http://localhost:" + port + "/")
     })
   })
 


### PR DESCRIPTION
Allows you to cmd+click on the terminal message to open the URL where your server is running
