### PR TITLE
Changed 404 so it doesn't match index

### DIFF
--- a/lib/sample/404.jade
+++ b/lib/sample/404.jade
@@ -1,2 +1,2 @@
-h1 Welcome to Harp.
-h3 This is yours to own. Enjoy.
+h1 404
+h3 Whoops. Looks like what you're looking for can't be found. :(


### PR DESCRIPTION
Previously, the 404 message looked exactly that of index page, which, I'd imagine, would be confusing for many.

Changed it to a message more distinctive from `index.jade`.

Tackles issue #211.
