### PR TITLE
Failed compile exits with error

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -122,7 +122,10 @@ program
     }
 
     harp.compile(projectPath, outputPath, function(errors, output){
-      if(errors) console.log(JSON.stringify(errors, null, 2))
+      if(errors) {
+        console.log(JSON.stringify(errors, null, 2))
+        process.exit(1)
+      }
     })
   })
 


### PR DESCRIPTION
This will allow authors to use tool chains like `npm test` with `harp compile` and if used with Travis, could automatically deploy on successful compilation.

Let me know if you'd like more info. I've (perhaps incorrectly?) assumed that if there are errors in the compile, then the compile didn't happen (or you wouldn't want to push it live).
