### PR TITLE
Added ip binding for harp server (no multihost yet)

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -62,14 +62,22 @@ program
 
 program
   .command("server [path]")
+  .option("-i, --ip <ip>", "Specify IP to bind to")
   .option("-p, --port <port>", "Specify a port to listen on")
   .usage("starts a Harp server in current directory, or in the specified directory.")
   .description("Start a Harp server in current directory")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
+    var ip          = program.ip || '0.0.0.0'
     var port        = program.port || 9000
-    harp.server(projectPath, { port: port }, function(){
-      var hostUrl = "http://localhost:" + port + "/"
+    harp.server(projectPath, { ip: ip, port: port }, function(){
+      var address = ''
+      if(ip == '0.0.0.0' || ip == '127.0.0.1') {
+        address = 'localhost'
+      } else {
+        address = ip
+      }
+      var hostUrl = "http://" + address + ":" + port + "/"
       output("Your server is listening at " + hostUrl)
     })
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ exports.server = function(dirPath, options, callback){
     middleware.poly,
     middleware.process,
     middleware.fallback
-  ).listen(options.port || 9966, callback)
+  ).listen(options.port || 9966, options.ip, callback)
 }
 
 


### PR DESCRIPTION
This should fix issue [#146](https://github.com/sintaxi/harp/issues/146) when running single harp app. No support for multihost yet.

When running `harp server` you can specify ip to bind to using `-i` or `--ip` options. Default it will listen to `0.0.0.0`/ all ip address.