### PR TITLE
Fixed that middleware.setup calles next() twice

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -364,7 +364,7 @@ exports.static = function(req, res, next) {
  */
 
 exports.setup = function(req, rsp, next){
-  if(req.hasOwnProperty('setup')) next()
+  if(req.hasOwnProperty('setup')) return next()
 
   try{
     req.setup = helpers.setup(req.projectPath)


### PR DESCRIPTION
Happens when request already has a property `setup`.
