### PR TITLE
Allow setting locals prior to harp processing

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -459,7 +459,7 @@ exports.process = function(req, rsp, next){
    * Now we let Polymer handle the asset pipeline.
    */
 
-  req.poly.render(sourceFile, function(error, body){
+  req.poly.render(sourceFile, rsp.locals || {}, function(error, body){
     if(error){
       error.stack = helpers.stacktrace(error.stack, { lineno: error.lineno })
 


### PR DESCRIPTION
e.g.

``` js
app.get('/search', function(req, res, next) {
  doSearch(req.query.q, function(err, searchResults) {
    res.locals = {
      searchResults: searchResults
    };
    next();
  });
});

app.configure(function(){
  app.use(express.static(publicDir));
  app.use(harp.mount(publicDir));
});
```
