### PR TITLE
Added option to specify address to listen on

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -75,12 +75,14 @@ program
 program
   .command("server [path]")
   .option("-p, --port <port>", "Specify a port to listen on")
+  .option("-a, --address <address> ", "Specify what address to listen on")
   .usage("starts a Harp server in current directory, or in the specified directory.")
   .description("Start a Harp server in current directory")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
     var port        = program.port || 9000
-    harp.server(projectPath, { port: port }, function(){
+    var address     = program.address || "0.0.0.0"
+    harp.server(projectPath, { port: port, address: address }, function(){
       var hostUrl = "http://localhost:" + port + "/"
       output("Your server is listening at " + hostUrl)
     })
@@ -89,12 +91,14 @@ program
 program
   .command("multihost [path]")
   .option("-p, --port <port>", "Specify a port to listen on")
+  .option("-a, --address <address>", "Specify what address to listen on")
   .usage("starts a Harp server to host a directory of Harp projects.")
   .description("Start a Harp server to host a directory of Harp projects")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
     var port        = program.port || 9000
-    harp.multihost(projectPath, { port: port }, function(){
+    var address     = program.address || "0.0.0.0"
+    harp.multihost(projectPath, { port: port, address: address }, function(){
       if(port == "80"){
         var loc = "http://harp.nu"
       }else{

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ exports.server = function(dirPath, options, callback){
     middleware.poly,
     middleware.process,
     middleware.fallback
-  ).listen(options.port || 9000, callback)
+  ).listen(options.port || 9000, options.address || '0.0.0.0', callback)
 }
 
 
@@ -51,7 +51,7 @@ exports.multihost = function(dirPath, options, callback){
     middleware.poly,
     middleware.process,
     middleware.fallback
-  ).listen(options.port || 9000, callback)
+  ).listen(options.port || 9000, options.address || '0.0.0.0', callback)
 }
 
 /**


### PR DESCRIPTION
I noticed how Harp is unable to listen on alternative IP addresses, other than Node.js' default `0.0.0.0`. I suggest that we have the option to specify which IP address that Harp will listen on.

This pull request adds an `-a` or `--address` option to Harp's command-line utility, and Harp's API now accepts an `address` option when calling the `server` method.

--------

Typically, when an application is listening on `0.0.0.0`, all packets sent to the host will be sent to the application that is listening on `0.0.0.0` (assuming that there aren't any application listening on *the* specific IP address of the host, e.g. `192.168.1.70`).

Contrast `0.0.0.0` to the loopback IP address, `127.0.0.1`. When the operating system receives either TCP or UDP packets that are not from the loopback address, if there aren't any applications listening on either the address assigned to the network interface (again, e.g. `192.168.1.70`), *or* `0.0.0.0`, then the operating system will simply drop those packets.

And, as a result, **allowing applications (e.g.. Harp) to listen on loopback allows for a certain level of privacy**.

A use case here is when Harp is sitting behind a reverse proxy. More often than not, Harp being proxied is most likely listening on a port *other* than `80`, say, `9000`. If Harp were to listen on `0.0.0.0`, then clients will be able to request the site on *both* ports `80`, *and*, `9000`, which may be an undesirable result for many website admins.

And so, for the sake of security, it might be a good idea to allow users to specify what address to listen on.

I was indirectly motivated to issue this pull request based on #294.