### PR TITLE
add 304 cache controll base on content hash

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -6,6 +6,7 @@ var terraform       = require('terraform')
 var pkg             = require('../package.json')
 var skin            = require('./skin')
 var connect         = require('connect')
+var crypto          = require('crypto')
 
 var send = require('../node_modules/connect/node_modules/send')
   , utils = require('../node_modules/connect/lib/utils')
@@ -513,14 +514,20 @@ exports.process = function(req, rsp, next){
     }else{
       // 404
       if(!body) return next()
-
-      var outputType = terraform.helpers.outputType(sourceFile)
-      var mimeType   = helpers.mimeType(outputType)
-      var charset    = mime.charsets.lookup(mimeType)
-      rsp.statusCode = 200
-      rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
-      rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
-      rsp.end(body);
+      var hash = crypto.createHash('md5').update(body).digest('hex')
+      if (req.headers['if-none-match'] === hash) {
+        rsp.statusCode = 304
+        rsp.end()
+      }else{
+        var outputType = terraform.helpers.outputType(sourceFile)
+        var mimeType   = helpers.mimeType(outputType)
+        var charset    = mime.charsets.lookup(mimeType)
+        rsp.statusCode = 200
+        rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
+        rsp.setHeader('Content-Length', Buffer.byteLength(body, charset))
+        rsp.setHeader('ETag', hash)
+        rsp.end(body)
+      }
     }
   })
 


### PR DESCRIPTION
fix https://github.com/sintaxi/harp/issues/300

set etag base on body md5 hash
if equal return 304 instead of re-send the file

this is a temporary solution for cache controll
for there is no good cache method, detail in https://github.com/sintaxi/harp/pull/79

i don't know if there is a good idea for cache
