### PR TITLE
Implementing browser-sync

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -7,6 +7,7 @@ var downloadRepo  = require("download-github-repo")
 var pkg           = require("../package.json")
 var helpers       = require("../lib/helpers")
 var harp          = require("../")
+var browserSync   = require("browser-sync")
 
 var output = function(msg){
   var v = pkg.version
@@ -75,14 +76,30 @@ program
 program
   .command("server [path]")
   .option("-p, --port <port>", "Specify a port to listen on")
+  .option("-w, --watch [port]", "Enable browser-sync for livereload - Optional: Specify port for browser-sync")
   .usage("starts a Harp server in current directory, or in the specified directory.")
   .description("Start a Harp server in current directory")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
     var port        = program.port || 9000
+    var browserSyncPort = (typeof program.watch !== "boolean") ? program.watch : port + 1
+    if(program.watch) {
+      browserSync({
+        files: [projectPath + '/**/*'],
+        proxy: "localhost:" + port,
+        open: false,
+        port: browserSyncPort,
+        logLevel: "silent"
+      });
+    }
     harp.server(projectPath, { port: port }, function(){
       var hostUrl = "http://localhost:" + port + "/"
-      output("Your server is listening at " + hostUrl)
+      var browserSyncUrl = "http://localhost:" + browserSyncPort + "/"
+      var log = "Your server is listening at " + hostUrl;
+      if(program.watch){
+        log += "\n\rBrowser-sync is enabled on " + browserSyncUrl
+      }
+      output(log)
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "terraform": "0.9.0",
+    "browser-sync": "1.5.7",
     "commander": "2.0.0",
     "connect": "2.9.0",
     "fs-extra": "0.6.4",


### PR DESCRIPTION
First draft for implementing browser-sync into harp.

I choose to implement it in the `bin/harp` because I do not think if you are using harp as a express middleware that you perhaps want browser-sync necessary.

Browser-sync does not have a documented way to let yourself inject the javascript that is uses, but that would also make it more complicated (prefer simple).

I made it so that browsersync as standard is one port above harp because that would make it easy to switch between basic and browser-sync.

Read about browser-sync here www.browsersync.io

But it is fairly simple, it sets up a proxy to your original server where it injects a socket.io javascript and then you set up a file glob on which files it should watch.

How to test:

```
bin/harp server test/apps/basic/public/ -w
```

![harp](https://cloud.githubusercontent.com/assets/1126497/4604443/09565598-519e-11e4-93af-e0f88169c6c6.gif)

