### PR TITLE
Directory Indexes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var terraform   = require('terraform')
 var async       = require('async')
 var connect     = require('connect')
 var mime        = require('mime')
+var http        = require('http')
 var helpers     = require('./helpers')
 var middleware  = require('./middleware')
 var pkg         = require('../package.json')
@@ -191,6 +192,8 @@ exports.compile = function(projectPath, outputPath, callback){
    */
 
   var compileFile = function(file, done){
+    var codes = http.STATUS_CODES
+    var match
     process.nextTick(function () {
       terra.render(file, function(error, body){
         if(error){
@@ -198,9 +201,8 @@ exports.compile = function(projectPath, outputPath, callback){
         }else{
           if(body){
             var dest = path.resolve(outputPath, terraform.helpers.outputPath(file))
-            var match
             if(match = (/^.*\/(.*?)\.html$/).exec(dest)) {
-              if(!match[1].match(/^[0-9]+$/) && match[1] !== "index") {
+              if(match[1] !== "index" && !codes.hasOwnProperty(match[1])) {
                 dest = dest.replace(/\.html$/, "/index.html")
               }
             }

--- a/test/apps/compile/basic/public/777.jade
+++ b/test/apps/compile/basic/public/777.jade
@@ -1,0 +1,2 @@
+h1 777
+p A numerically named page, but not an error

--- a/test/compile.js
+++ b/test/compile.js
@@ -28,6 +28,16 @@ describe("compile", function(){
       done()
     })
 
+    it("compile should ignore files named after http statuses when creating directory indexes", function(done){
+      var rsp = fs.existsSync(path.join(outputPath, "/404.html"))
+      rsp.should.be.true
+
+      var rsp = fs.existsSync(path.join(outputPath, "/777/index.html"))
+      rsp.should.be.true
+
+      done()
+    })
+
     it("compile should not include folders named with underscores", function(done) {
       var cssOutputPath = path.join(outputPath, "/css")
 


### PR DESCRIPTION
I need directory indexes so I made this tiny hack. Do with it what you will.

How it works:

`404.html` = `404.html`
`about.ejs` = `about/index.html` (preferred way of doing things)
`folder/index.ejs` = `folder/index.html` (how it is right now in `0.14.0`, and it still works)
`index.ejs` = `index.html`

And that's it.

There are no tests. Should I create some?
