### PR TITLE
align package.json description with readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harp",
   "version": "0.14.0",
-  "description": "Static web server with built in preprocessing",
+  "description": "zero-configuration web server with built in pre-processing",
   "author": "Brock Whitten <brock@chloi.io>",
   "contributors":
   [ "Brock Whitten <brock@chloi.io>"


### PR DESCRIPTION
This irons out a kink in the way harp looks on the new npm website: https://preview.npmjs.com/package/harp

![screen shot 2014-11-05 at 2 25 52 pm](https://cloud.githubusercontent.com/assets/2289/4927355/cec2e7d8-653a-11e4-878a-d1c9b8be4f0c.png)

I'm working on making npm/newww [smart enough to fix these redundancies](https://github.com/npm/newww/blob/b94555fa4d55879ab4c370fa14b7e78924ba82fc/facets/registry/presenters/package.js#L349-L361), but it's still a work in progress.