### PR TITLE
fix a bug when a url include chinese charaters

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -459,7 +459,7 @@ var poly = exports.poly = function(req, rsp, next){
  */
 
 exports.process = function(req, rsp, next){
-  var normalizedPath  = helpers.normalizeUrl(req.url)
+  var normalizedPath  = helpers.normalizeUrl(decodeURIComponent(req.url))
   var priorityList    = terraform.helpers.buildPriorityList(normalizedPath)
   var sourceFile      = terraform.helpers.findFirstFile(req.setup.publicPath, priorityList)
 


### PR DESCRIPTION
when a url include chinese charaters, show 404, for
example:http://localhost:9000/新年活动/提交成功