### PR TITLE
Expose notFound middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ var app = express();
 app.configure(function(){
   app.use(express.static(__dirname + "/public"));
   app.use(harp.mount(__dirname + "/public"));
+
+  // Optionally use harp middleware to serve 404 page
+  app.use(harp.notFound);
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,13 @@ exports.mount = function(mountPoint, root){
   }
 }
 
+/**
+ * NotFound
+ *
+ * Offer 404 handler as connect middleware
+ */
+
+exports.notFound = middleware.notFound;
 
 /**
  * Pipeline


### PR DESCRIPTION
This PR exposes notFound middleware so that it can be used when mounting harp as part of Connect/Express app. This resolves #407