### PR TITLE
Expose middleware when Harp is used as library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,6 +134,14 @@ exports.pipeline = function(root){
 
 exports.pkg = pkg
 
+/**
+ * Export middleware
+ *
+ * Make sure middleware is accessible
+ * when using harp as a library
+ *
+ */
+exports.middleware = middleware;
 
 /**
  * Compile

--- a/test/lib.js
+++ b/test/lib.js
@@ -1,0 +1,15 @@
+var should      = require("should")
+var harp = require('../lib');
+var middleware = require('../lib/middleware');
+
+describe("harp as a library", function() {
+
+  it("should expose a mount function", function() {
+    should(harp.mount).be.type('function');
+  });
+
+  it("should expose the middleware", function() {
+    should(harp.middleware).be.equal(middleware);
+  });
+
+});


### PR DESCRIPTION
This PR exposes the middleware when Harp is used as a library.

### Problem

Currently the recommended way of loading Harp as a library, is to:

```javascript
var express = require("express");
var harp = require("harp");
var app = express();

app.configure(function(){
  app.use(express.static(__dirname + "/public"));
  app.use(harp.mount(__dirname + "/public"));
});
```

Using `harp.mount()` does not load the same layers of middleware that a regular Harp server (using `harp.server()`) does.

For example, to make `200.jade` act as a catch-all when using Harp as a library, you have to add the `fallback` middleware but there is no clean way of doing this without resorting to nasty code like:

```javascript
var harpMiddleware = require('./node_modules/harp/lib/middleware');

app.use(express.static(__dirname + "/public"));
app.use(harp.mount(__dirname + "/public"));
app.use(harpMiddleware.fallback);
```

### Solution

This PR exposes the `middleware` on the `harp` object so every existing Harp middleware can be conveniently accessed:

```javascript
app.use(express.static(__dirname + "/public"));
app.use(harp.mount(__dirname + "/public"));
app.use(harp.middleware.fallback);
```

Because all Harp middleware is exposed, you can conveniently add several layers of additional middleware such as `fallback`, `notFound`, `underscore`, etc and order hem in a way that makes sense for your application.

### Unit tests

Unit test have been added to test if Harp exposes the right middleware when loaded as a library.

All existing tests remain successful:

```bash
88 tests complete (7 seconds)
```

### Other

This PR also resolves #413, #407 and #266 (and possibly other issues).