### PR TITLE
Support for Hjson/CSON config files

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,7 @@ var terraform = require('terraform')
 var fse     = require('fs-extra')
 var envy    = require('envy-json')
 var CSON    = require('cson')
-var Hjson   = require('hjson')
+var HJSON   = require('hjson')
 
 /**
  *
@@ -127,57 +127,41 @@ exports.ls = function(dir, callback) {
  */
 
 exports.setup = function(projectPath, env){
-  var configPath, contents, publicPath, cfg, format;
+  var configPath, contents, publicPath, cfg, format, i, file, files, exception, e;
   
   if(!env) env = "development"
 
-  try {
-    configPath  = path.join(projectPath, "harp.json")
-    contents    = fs.readFileSync(configPath).toString()
-    publicPath  = path.join(projectPath, "public")
-    format      = "JSON"
-  } catch(e) {
+  files = ["harp.json", "_harp.json"]
+    
+  if (terraform.helpers.processors['json']) {
+    terraform.helpers.processors['json'].forEach(function(p) {
+      files.push("harp." + p, "_harp." + p)
+    })
+  }
+  files.push("") // empty JSON fallback
+  
+  exception = true
+  for (i = 0; i < files.length && exception; ++i) {
+    file = files[i]
+    exception = false
     try {
-      configPath  = path.join(projectPath, "_harp.json")
-      contents    = fs.readFileSync(configPath).toString()
-      publicPath  = projectPath
-      format      = "JSON"
-    } catch(e) {
-      try {
-        configPath  = path.join(projectPath, "harp.cson")
-        contents    = fs.readFileSync(configPath).toString()
-        publicPath  = path.join(projectPath, "public")
-        format      = "CSON"
-      } catch(e) {
-        try {
-          configPath  = path.join(projectPath, "_harp.cson")
-          contents    = fs.readFileSync(configPath).toString()
-          publicPath  = projectPath
-          format      = "CSON"
-        } catch(e) {
-          try{
-            configPath  = path.join(projectPath, "harp.hjson")
-            contents    = fs.readFileSync(configPath).toString()
-            publicPath  = path.join(projectPath, "public")
-            format      = "HJSON"
-          }catch(e){
-            try{
-              configPath  = path.join(projectPath, "_harp.hjson")
-              contents    = fs.readFileSync(configPath).toString()
-              publicPath  = projectPath
-              format      = "HJSON"
-            }catch(e){
-              contents    = "{}"
-              publicPath  = projectPath
-              format      = "JSON"
-            }
-          }
-        }
+      if (file) {
+        configPath = path.join(projectPath, file)
+        contents   = fs.readFileSync(configPath).toString()
+        publicPath = (file[0] === '_' ? projectPath : path.join(projectPath, "public"))
+        format     = path.extname(file).substring(1).toUpperCase()
+      } else {
+        configPath = null
+        contents   = "{}"
+        publicPath = projectPath
+        format     = "JSON"
       }
+    } catch(e) {
+      exception = true
     }
   }
 
-  // not sure what this does anymore.
+  // empty strings are invalid JSON, but shouldn't throw an error regardless
   if(!contents || contents.replace(/^\s\s*/, '').replace(/\s\s*$/, '') == ''){
     contents = '{}'
     format = "JSON"
@@ -191,7 +175,7 @@ exports.setup = function(projectPath, env){
         if (cfg.constructor != Object) throw cfg
         break
       case "HJSON":
-        cfg = Hjson.parse(contents)
+        cfg = HJSON.parse(contents)
         break
       default:
         cfg = JSON.parse(contents)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,8 @@ var mime    = require('mime')
 var terraform = require('terraform')
 var fse     = require('fs-extra')
 var envy    = require('envy-json')
+var CSON    = require('cson')
+var Hjson   = require('hjson')
 
 /**
  *
@@ -125,33 +127,77 @@ exports.ls = function(dir, callback) {
  */
 
 exports.setup = function(projectPath, env){
+  var configPath, contents, publicPath, cfg, format;
+  
   if(!env) env = "development"
 
-  try{
-    var configPath  = path.join(projectPath, "harp.json")
-    var contents    = fs.readFileSync(configPath).toString()
-    var publicPath  = path.join(projectPath, "public")
-  }catch(e){
-    try{
-      var configPath  = path.join(projectPath, "_harp.json")
-      var contents    = fs.readFileSync(configPath).toString()
-      var publicPath  = projectPath
-    }catch(e){
-      var contents    = "{}"
-      var publicPath  = projectPath
+  try {
+    configPath  = path.join(projectPath, "harp.json")
+    contents    = fs.readFileSync(configPath).toString()
+    publicPath  = path.join(projectPath, "public")
+    format      = "JSON"
+  } catch(e) {
+    try {
+      configPath  = path.join(projectPath, "_harp.json")
+      contents    = fs.readFileSync(configPath).toString()
+      publicPath  = projectPath
+      format      = "JSON"
+    } catch(e) {
+      try {
+        configPath  = path.join(projectPath, "harp.cson")
+        contents    = fs.readFileSync(configPath).toString()
+        publicPath  = path.join(projectPath, "public")
+        format      = "CSON"
+      } catch(e) {
+        try {
+          configPath  = path.join(projectPath, "_harp.cson")
+          contents    = fs.readFileSync(configPath).toString()
+          publicPath  = projectPath
+          format      = "CSON"
+        } catch(e) {
+          try{
+            configPath  = path.join(projectPath, "harp.hjson")
+            contents    = fs.readFileSync(configPath).toString()
+            publicPath  = path.join(projectPath, "public")
+            format      = "HJSON"
+          }catch(e){
+            try{
+              configPath  = path.join(projectPath, "_harp.hjson")
+              contents    = fs.readFileSync(configPath).toString()
+              publicPath  = projectPath
+              format      = "HJSON"
+            }catch(e){
+              contents    = "{}"
+              publicPath  = projectPath
+              format      = "JSON"
+            }
+          }
+        }
+      }
     }
   }
 
   // not sure what this does anymore.
   if(!contents || contents.replace(/^\s\s*/, '').replace(/\s\s*$/, '') == ''){
     contents = '{}'
+    format = "JSON"
   }
 
   // attempt to parse the file
   try{
-    var cfg = JSON.parse(contents)
+    switch(format) {
+      case "CSON":
+        cfg = CSON.parse(contents)
+        if (cfg.constructor != Object) throw cfg
+        break
+      case "HJSON":
+        cfg = Hjson.parse(contents)
+        break
+      default:
+        cfg = JSON.parse(contents)
+    }
   }catch(e){
-    e.source    = "JSON"
+    e.source    = format
     e.dest      = "CONFIG"
     e.message   = e.message
     e.filename  = configPath

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -376,7 +376,7 @@ exports.static = function(req, res, next) {
 }
 
 /**
- * Opens the (optional) harp.json file and sets the config settings.
+ * Opens the (optional) harp.json/harp.cson/harp.hjson file and sets the config settings.
  */
 
 exports.setup = function(req, rsp, next){

--- a/package.json
+++ b/package.json
@@ -3,27 +3,33 @@
   "version": "0.17.0",
   "description": "Static web server with built in preprocessing",
   "author": "Brock Whitten <brock@chloi.io>",
-  "contributors":
-  [ "Brock Whitten <brock@chloi.io>"
-  , "Rob Ellis <rob@chloi.io>"
-  , "Jorge Pedret <jorge@chloi.io>"
-  , "Michael Brooks <michael@michaelbrooks.ca>"
-  , "Tommy-Carlos Williams <tommy@devgeeks.org>"
-  , "Darryl Pogue <darryl@dpogue.ca>"
-  , "Boris Mann <boris@bmannconsulting.com>"
-  , "Kenneth Ormandy <kenneth@chloi.io>"
-  , "Keith Yao <i@yaofur.com>"
-  , "Eric Drechsel <eric@pdxhub.org>"
-  , "Andrew Hobden <andrew@hoverbear.org>"
-  , "Max Melentiev <printercu@gmail.com>"
-  , "Remy Sharp <remy@remysharp.com>"
-  , "Zeke Sikelianos <zeke@sikelianos.com>"
-  , "Marc Knaup <marc.knaup@koeln.de>"
+  "contributors": [
+    "Brock Whitten <brock@chloi.io>",
+    "Rob Ellis <rob@chloi.io>",
+    "Jorge Pedret <jorge@chloi.io>",
+    "Michael Brooks <michael@michaelbrooks.ca>",
+    "Tommy-Carlos Williams <tommy@devgeeks.org>",
+    "Darryl Pogue <darryl@dpogue.ca>",
+    "Boris Mann <boris@bmannconsulting.com>",
+    "Kenneth Ormandy <kenneth@chloi.io>",
+    "Keith Yao <i@yaofur.com>",
+    "Eric Drechsel <eric@pdxhub.org>",
+    "Andrew Hobden <andrew@hoverbear.org>",
+    "Max Melentiev <printercu@gmail.com>",
+    "Remy Sharp <remy@remysharp.com>",
+    "Zeke Sikelianos <zeke@sikelianos.com>",
+    "Marc Knaup <marc.knaup@koeln.de>"
   ],
   "keywords": [
     "static web server",
     "static site generator",
-    "sass", "less", "stylus", "markdown", "jade", "ejs", "coffeescript"
+    "sass",
+    "less",
+    "stylus",
+    "markdown",
+    "jade",
+    "ejs",
+    "coffeescript"
   ],
   "homepage": "http://harpjs.com",
   "bugs": "http://github.com/sintaxi/harp/issues",
@@ -33,14 +39,16 @@
     "url": "https://github.com/sintaxi/harp.git"
   },
   "dependencies": {
-    "terraform": "0.11.0",
+    "async": "0.2.9",
     "commander": "2.0.0",
     "connect": "2.9.0",
-    "async": "0.2.9",
-    "fs-extra": "0.18.2",
-    "mime": "1.2.11",
+    "cson": "^3.0.1",
     "download-github-repo": "0.1.3",
-    "envy-json": "0.2.1"
+    "envy-json": "0.2.1",
+    "fs-extra": "0.18.2",
+    "hjson": "^1.7.3",
+    "mime": "1.2.11",
+    "terraform": "0.11.0"
   },
   "devDependencies": {
     "mocha": "1.8.1",

--- a/test/apps/basic-cson/README.md
+++ b/test/apps/basic-cson/README.md
@@ -1,0 +1,4 @@
+# Example Harp App
+==================
+
+This app exposes a lot of the functionality that Harp offers. Browse the code and take a look. Questions may be asked in the #harp IRC channel on irc.freenode.net.

--- a/test/apps/basic-cson/harp.cson
+++ b/test/apps/basic-cson/harp.cson
@@ -1,0 +1,5 @@
+globals:
+  brand: "Kitchen Sink"
+  name: "Brock Whitten"
+  email: "brock@chloi.io"
+  uri: "http://example.com"

--- a/test/apps/basic-cson/public/404.jade
+++ b/test/apps/basic-cson/public/404.jade
@@ -1,0 +1,11 @@
+doctype
+html
+	head
+		style.
+			body{
+				text-align:center;
+				font-family: "verdana";
+			}
+	body
+		h1 404
+		h2 Custom, Page Not Found

--- a/test/apps/basic-cson/public/_data.cson
+++ b/test/apps/basic-cson/public/_data.cson
@@ -1,0 +1,14 @@
+404:
+  layout: false
+
+feed:
+  layout: false
+
+globals:
+  layout: false
+
+current:
+  layout: false
+  
+about:
+  name: "Brock"

--- a/test/apps/basic-cson/public/_layout.jade
+++ b/test/apps/basic-cson/public/_layout.jade
@@ -1,0 +1,19 @@
+doctype
+html
+  head
+    link(rel="stylesheet", href="/css/main.css")
+    link(rel="alternate", type="application/atom+xml", title="#{ brand }", href="#{ uri }/feed.atom")
+    script.
+      var showDebug = function(){
+        document.getElementById('debug').style.display = 'block';
+        return false;
+      }
+  body
+    #header
+      h1= brand
+      include shared/_nav
+      != yield
+      a(href="#", onclick="showDebug()") open debug panel
+      .well#debug(style="display:none;")
+        != partial("shared/_debug")
+

--- a/test/apps/basic-cson/public/about.jade
+++ b/test/apps/basic-cson/public/about.jade
@@ -1,0 +1,2 @@
+h2 About #{ name }
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/test/apps/basic-cson/public/articles/_data.cson
+++ b/test/apps/basic-cson/public/articles/_data.cson
@@ -1,0 +1,7 @@
+"hello-world":
+  title : "Hello World"
+  date  : "May 2, 2012"
+
+"you-half-assed-it":
+  title : "You half assed it. That is why your PhoneGap application sucks."
+  date  : "June 6, 2012"

--- a/test/apps/basic-cson/public/articles/hello-world.jade
+++ b/test/apps/basic-cson/public/articles/hello-world.jade
@@ -1,0 +1,6 @@
+h2
+  a(href="/articles/hello-world") Hello World
+h3= date
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+//!= partial("../shared/_debug")

--- a/test/apps/basic-cson/public/articles/index.jade
+++ b/test/apps/basic-cson/public/articles/index.jade
@@ -1,0 +1,4 @@
+h2 Articles
+each article, slug in public.articles._data
+  hr
+  != partial(slug, article)

--- a/test/apps/basic-cson/public/articles/with spaces.md
+++ b/test/apps/basic-cson/public/articles/with spaces.md
@@ -1,0 +1,1 @@
+foo article with spaces

--- a/test/apps/basic-cson/public/articles/you-half-assed-it.jade
+++ b/test/apps/basic-cson/public/articles/you-half-assed-it.jade
@@ -1,0 +1,6 @@
+h2
+  a(href="/articles/you-half-assed-it") You Half assed it
+h3= date
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+//!= partial("../shared/_debug")

--- a/test/apps/basic-cson/public/basic.html
+++ b/test/apps/basic-cson/public/basic.html
@@ -1,0 +1,1 @@
+<h1>Basic HTML Page</h1>

--- a/test/apps/basic-cson/public/css/_nav.less
+++ b/test/apps/basic-cson/public/css/_nav.less
@@ -1,0 +1,23 @@
+#header {
+	
+  h1 {
+    font-size: 26px;
+    font-weight: bold;
+  }
+
+	ul{
+		list-style-type: none;
+		padding:0;
+	  li{
+			display: inline-block;
+			margin-right: 20px;
+			a {
+				padding: 10px 5px;
+	    }
+	  }	
+		li.current a{
+	    background: pink;			
+		}
+	}
+
+}

--- a/test/apps/basic-cson/public/css/main.less
+++ b/test/apps/basic-cson/public/css/main.less
@@ -1,0 +1,9 @@
+@import "_nav";
+
+body{
+	font-family: "Verdana"
+}
+
+.well{
+  background: #eee;
+}

--- a/test/apps/basic-cson/public/current.json.jade
+++ b/test/apps/basic-cson/public/current.json.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(current)

--- a/test/apps/basic-cson/public/feed.atom.jade
+++ b/test/apps/basic-cson/public/feed.atom.jade
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+feed(xmlns='http://www.w3.org/2005/Atom')
+  title= brand
+  link(href="#{ uri }/articles.atom", rel="self", type="application/atom+xml")
+  link(href="#{ uri }", rel="alternate", type="text/html")
+  author
+    name= name
+    email= email
+    id= uri + "/"
+  each article, slug in public.articles._data
+    entry
+      title= article.title
+      id= uri + "/articles/" + slug
+      updated= article.date
+      link(href="#{ uri }/articles/#{ slug }", rel="alternate", type="text/html")

--- a/test/apps/basic-cson/public/globals.json.jade
+++ b/test/apps/basic-cson/public/globals.json.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(locals)

--- a/test/apps/basic-cson/public/index.jade
+++ b/test/apps/basic-cson/public/index.jade
@@ -1,0 +1,2 @@
+h2 Home
+p Welcome to Harp. This basic app is a domonstration of how harp works. Poke around and enjoy.

--- a/test/apps/basic-cson/public/shared/_debug.jade
+++ b/test/apps/basic-cson/public/shared/_debug.jade
@@ -1,0 +1,5 @@
+h4 globals
+pre= JSON.stringify(locals, null, 2)
+
+h4 current
+pre= JSON.stringify(current, null, 2)

--- a/test/apps/basic-cson/public/shared/_nav.jade
+++ b/test/apps/basic-cson/public/shared/_nav.jade
@@ -1,0 +1,9 @@
+ul
+  li(class="#{ current.path[0] == 'index' ? 'current' : '' }")
+    a(href="/") Home
+  li(class="#{ current.path[0] == 'articles' ? 'current' : '' }")
+    a(href="/articles") Articles
+  li(class="#{ current.path[0] == 'about' ? 'current' : '' }")
+    a(href="/about") About
+  li
+    a(href="/feed.atom") RSS

--- a/test/apps/basic-hjson/README.md
+++ b/test/apps/basic-hjson/README.md
@@ -1,0 +1,4 @@
+# Example Harp App
+==================
+
+This app exposes a lot of the functionality that Harp offers. Browse the code and take a look. Questions may be asked in the #harp IRC channel on irc.freenode.net.

--- a/test/apps/basic-hjson/harp.hjson
+++ b/test/apps/basic-hjson/harp.hjson
@@ -1,8 +1,8 @@
 {
   globals: {
-    brand : Kitchen Sink
-    name  : Brock Whitten
-    email : brock@chloi.io
-    uri   : http://example.com
+    brand: Kitchen Sink
+    name: Brock Whitten
+    email: brock@chloi.io
+    uri: "http://example.com"
   }
 }

--- a/test/apps/basic-hjson/harp.hjson
+++ b/test/apps/basic-hjson/harp.hjson
@@ -1,0 +1,8 @@
+{
+  globals: {
+    brand : Kitchen Sink
+    name  : Brock Whitten
+    email : brock@chloi.io
+    uri   : http://example.com
+  }
+}

--- a/test/apps/basic-hjson/public/404.jade
+++ b/test/apps/basic-hjson/public/404.jade
@@ -1,0 +1,11 @@
+doctype
+html
+	head
+		style.
+			body{
+				text-align:center;
+				font-family: "verdana";
+			}
+	body
+		h1 404
+		h2 Custom, Page Not Found

--- a/test/apps/basic-hjson/public/_data.hjson
+++ b/test/apps/basic-hjson/public/_data.hjson
@@ -2,16 +2,16 @@
   404: {
     layout: false
   }
-  feed:{
+  feed: {
     layout: false
   }
-  globals:{
+  globals: {
     layout: false
   }
-  current:{
+  current: {
     layout: false
   }
-  about": {
+  about: {
     name: Brock
   }
 }

--- a/test/apps/basic-hjson/public/_data.hjson
+++ b/test/apps/basic-hjson/public/_data.hjson
@@ -1,0 +1,17 @@
+{
+  404: {
+    layout: false
+  }
+  feed:{
+    layout: false
+  }
+  globals:{
+    layout: false
+  }
+  current:{
+    layout: false
+  }
+  about": {
+    name: Brock
+  }
+}

--- a/test/apps/basic-hjson/public/_layout.jade
+++ b/test/apps/basic-hjson/public/_layout.jade
@@ -1,0 +1,19 @@
+doctype
+html
+  head
+    link(rel="stylesheet", href="/css/main.css")
+    link(rel="alternate", type="application/atom+xml", title="#{ brand }", href="#{ uri }/feed.atom")
+    script.
+      var showDebug = function(){
+        document.getElementById('debug').style.display = 'block';
+        return false;
+      }
+  body
+    #header
+      h1= brand
+      include shared/_nav
+      != yield
+      a(href="#", onclick="showDebug()") open debug panel
+      .well#debug(style="display:none;")
+        != partial("shared/_debug")
+

--- a/test/apps/basic-hjson/public/about.jade
+++ b/test/apps/basic-hjson/public/about.jade
@@ -1,0 +1,2 @@
+h2 About #{ name }
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/test/apps/basic-hjson/public/articles/_data.hjson
+++ b/test/apps/basic-hjson/public/articles/_data.hjson
@@ -1,0 +1,10 @@
+{
+  hello-world: {
+    title: Hello World
+    date: May 2, 2012
+  }
+  you-half-assed-it: {
+    title: You half assed it. That is why your PhoneGap application sucks.
+    date: June 6, 2012
+  }
+}

--- a/test/apps/basic-hjson/public/articles/hello-world.jade
+++ b/test/apps/basic-hjson/public/articles/hello-world.jade
@@ -1,0 +1,6 @@
+h2
+  a(href="/articles/hello-world") Hello World
+h3= date
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+//!= partial("../shared/_debug")

--- a/test/apps/basic-hjson/public/articles/index.jade
+++ b/test/apps/basic-hjson/public/articles/index.jade
@@ -1,0 +1,4 @@
+h2 Articles
+each article, slug in public.articles._data
+  hr
+  != partial(slug, article)

--- a/test/apps/basic-hjson/public/articles/with spaces.md
+++ b/test/apps/basic-hjson/public/articles/with spaces.md
@@ -1,0 +1,1 @@
+foo article with spaces

--- a/test/apps/basic-hjson/public/articles/you-half-assed-it.jade
+++ b/test/apps/basic-hjson/public/articles/you-half-assed-it.jade
@@ -1,0 +1,6 @@
+h2
+  a(href="/articles/you-half-assed-it") You Half assed it
+h3= date
+p Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+//!= partial("../shared/_debug")

--- a/test/apps/basic-hjson/public/basic.html
+++ b/test/apps/basic-hjson/public/basic.html
@@ -1,0 +1,1 @@
+<h1>Basic HTML Page</h1>

--- a/test/apps/basic-hjson/public/css/_nav.less
+++ b/test/apps/basic-hjson/public/css/_nav.less
@@ -1,0 +1,23 @@
+#header {
+	
+  h1 {
+    font-size: 26px;
+    font-weight: bold;
+  }
+
+	ul{
+		list-style-type: none;
+		padding:0;
+	  li{
+			display: inline-block;
+			margin-right: 20px;
+			a {
+				padding: 10px 5px;
+	    }
+	  }	
+		li.current a{
+	    background: pink;			
+		}
+	}
+
+}

--- a/test/apps/basic-hjson/public/css/main.less
+++ b/test/apps/basic-hjson/public/css/main.less
@@ -1,0 +1,9 @@
+@import "_nav";
+
+body{
+	font-family: "Verdana"
+}
+
+.well{
+  background: #eee;
+}

--- a/test/apps/basic-hjson/public/current.json.jade
+++ b/test/apps/basic-hjson/public/current.json.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(current)

--- a/test/apps/basic-hjson/public/feed.atom.jade
+++ b/test/apps/basic-hjson/public/feed.atom.jade
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+feed(xmlns='http://www.w3.org/2005/Atom')
+  title= brand
+  link(href="#{ uri }/articles.atom", rel="self", type="application/atom+xml")
+  link(href="#{ uri }", rel="alternate", type="text/html")
+  author
+    name= name
+    email= email
+    id= uri + "/"
+  each article, slug in public.articles._data
+    entry
+      title= article.title
+      id= uri + "/articles/" + slug
+      updated= article.date
+      link(href="#{ uri }/articles/#{ slug }", rel="alternate", type="text/html")

--- a/test/apps/basic-hjson/public/globals.json.jade
+++ b/test/apps/basic-hjson/public/globals.json.jade
@@ -1,0 +1,1 @@
+!= JSON.stringify(locals)

--- a/test/apps/basic-hjson/public/index.jade
+++ b/test/apps/basic-hjson/public/index.jade
@@ -1,0 +1,2 @@
+h2 Home
+p Welcome to Harp. This basic app is a domonstration of how harp works. Poke around and enjoy.

--- a/test/apps/basic-hjson/public/shared/_debug.jade
+++ b/test/apps/basic-hjson/public/shared/_debug.jade
@@ -1,0 +1,5 @@
+h4 globals
+pre= JSON.stringify(locals, null, 2)
+
+h4 current
+pre= JSON.stringify(current, null, 2)

--- a/test/apps/basic-hjson/public/shared/_nav.jade
+++ b/test/apps/basic-hjson/public/shared/_nav.jade
@@ -1,0 +1,9 @@
+ul
+  li(class="#{ current.path[0] == 'index' ? 'current' : '' }")
+    a(href="/") Home
+  li(class="#{ current.path[0] == 'articles' ? 'current' : '' }")
+    a(href="/articles") Articles
+  li(class="#{ current.path[0] == 'about' ? 'current' : '' }")
+    a(href="/about") About
+  li
+    a(href="/feed.atom") RSS

--- a/test/apps/err-invalid-config-cson/harp.cson
+++ b/test/apps/err-invalid-config-cson/harp.cson
@@ -1,0 +1,3 @@
+globals:
+  name "missing colon"
+  email: "brock@chloi.io"

--- a/test/apps/err-invalid-config-cson/public/index.jade
+++ b/test/apps/err-invalid-config-cson/public/index.jade
@@ -1,0 +1,2 @@
+h2 Home
+p Welcome to Harp. This app has an invalid JSON file.

--- a/test/apps/err-invalid-config-hjson/harp.hjson
+++ b/test/apps/err-invalid-config-hjson/harp.hjson
@@ -1,0 +1,4 @@
+globals: {
+  name missing colon
+  email: brock@chloi.io
+}

--- a/test/apps/err-invalid-config-hjson/public/index.jade
+++ b/test/apps/err-invalid-config-hjson/public/index.jade
@@ -1,0 +1,2 @@
+h2 Home
+p Welcome to Harp. This app has an invalid JSON file.

--- a/test/apps/err-invalid-data-cson/public/_data.cson
+++ b/test/apps/err-invalid-data-cson/public/_data.cson
@@ -1,0 +1,1 @@
+invalid: cson

--- a/test/apps/err-invalid-data-hjson/public/_data.hjson
+++ b/test/apps/err-invalid-data-hjson/public/_data.hjson
@@ -1,0 +1,1 @@
+invalid hjson

--- a/test/basic.js
+++ b/test/basic.js
@@ -133,3 +133,261 @@ describe("basic", function(){
   })
 
 })
+
+describe("basic-cson", function(){
+  var projectPath = path.join(__dirname, "apps/basic-cson")
+  var outputPath  = path.join(__dirname, "out/basic-cson")
+
+  var config;
+
+  before(function(done){
+    harp.compile(projectPath, outputPath, function(errors, output){
+      config = output
+      harp.server(projectPath, { port: 8101 }, done)
+    })
+  })
+
+  it("should have node version in config", function(done){
+    config.should.have.property("harp_version")
+    done()
+  })
+
+  it("should have global vars", function(done){
+    var staticGlobals = require(path.join(outputPath, "globals.json"))
+    staticGlobals.should.have.property("environment", "production")
+    staticGlobals.should.have.property("public")
+    request('http://localhost:8100/globals.json', function (e, r, b) {
+      r.statusCode.should.eql(200)
+      var dynamicGlobals = JSON.parse(b)
+      dynamicGlobals.should.have.property("environment", "development")
+      dynamicGlobals.should.have.property("public")
+      done()
+    })
+  })
+
+  it("should have current vars", function(done){
+    var staticCurrent = require(path.join(outputPath, "current.json"))
+    staticCurrent.should.have.property("path")
+    staticCurrent.should.have.property("source", "current")
+    request('http://localhost:8100/current.json', function (e, r, b) {
+      r.statusCode.should.eql(200)
+      var dynamicCurrent = JSON.parse(b)
+      dynamicCurrent.should.have.property("path")
+      dynamicCurrent.should.have.property("source", "current")
+      done()
+    })
+  })
+
+  it("should have index file that uses the layout", function(done){
+    fs.readFile(path.join(outputPath, "index.html"), function(err, contents){
+      contents.toString().should.include("Kitchen Sink")
+      contents.toString().should.include("Home")
+      request('http://localhost:8100/', function (e, r, b) {
+        r.statusCode.should.eql(200)
+        b.should.include("Kitchen Sink")
+        b.should.include("Home")
+        done()
+      })
+    })
+  })
+
+  it("should have custom 404 page that does not use layout", function(done){
+    fs.readFile(path.join(outputPath, "404.html"), function(err, contents){
+      contents.toString().should.not.include("Kitchen Sink")
+      contents.toString().should.include("Custom, Page Not Found")
+      request('http://localhost:8100/some/missing/path', function (e, r, b) {
+        r.statusCode.should.eql(404)
+        r.headers.should.have.property("content-type", "text/html; charset=UTF-8")
+        b.should.not.include("Kitchen Sink")
+        b.should.include("Custom, Page Not Found")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should return CSS file", function(done){
+    fs.readFile(path.join(outputPath, "css", "main.css"), function(err, contents){
+      contents.toString().should.include("background")
+      request('http://localhost:8100/css/main.css', function (e, r, b) {
+        r.statusCode.should.eql(200)
+        b.should.include("background")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should return proper mime type on 404 page", function(done){
+    request('http://localhost:8100/some/missing/path.css', function (e, r, b) {
+      r.statusCode.should.eql(404)
+      r.headers.should.have.property("content-type", "text/html; charset=UTF-8")
+      done()
+    })
+  })
+
+  it("should render HTML page without requiring extension", function(done){
+    fs.readFile(path.join(outputPath, "basic.html"), function(err, contents){
+      contents.toString().should.not.include("Kitchen Sink")
+      contents.toString().should.include("<h1>Basic HTML Page</h1>")
+      request('http://localhost:8100/basic', function(e,r,b){
+        r.statusCode.should.eql(200)
+        b.should.not.include("Kitchen Sink")
+        b.should.include("<h1>Basic HTML Page</h1>")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should not return file starting with underscore", function(done){
+    request('http://localhost:8100/shared/_nav.jade', function(e,r,b){
+      r.statusCode.should.eql(404)
+      done()
+    })
+  })
+
+  it("should render HTML page with spaces in the file name", function(done){
+    request('http://localhost:8100/articles/with%20spaces', function(e,r,b){
+      r.statusCode.should.eql(200)
+      b.should.include("foo article")
+      done()
+    })
+  })
+
+  after(function(done){
+    exec("rm -rf " + outputPath, function(){
+      done()
+    })
+  })
+
+})
+
+describe("basic-hjson", function(){
+  var projectPath = path.join(__dirname, "apps/basic-hjson")
+  var outputPath  = path.join(__dirname, "out/basic-hjson")
+
+  var config;
+
+  before(function(done){
+    harp.compile(projectPath, outputPath, function(errors, output){
+      config = output
+      harp.server(projectPath, { port: 8102 }, done)
+    })
+  })
+
+  it("should have node version in config", function(done){
+    config.should.have.property("harp_version")
+    done()
+  })
+
+  it("should have global vars", function(done){
+    var staticGlobals = require(path.join(outputPath, "globals.json"))
+    staticGlobals.should.have.property("environment", "production")
+    staticGlobals.should.have.property("public")
+    request('http://localhost:8100/globals.json', function (e, r, b) {
+      r.statusCode.should.eql(200)
+      var dynamicGlobals = JSON.parse(b)
+      dynamicGlobals.should.have.property("environment", "development")
+      dynamicGlobals.should.have.property("public")
+      done()
+    })
+  })
+
+  it("should have current vars", function(done){
+    var staticCurrent = require(path.join(outputPath, "current.json"))
+    staticCurrent.should.have.property("path")
+    staticCurrent.should.have.property("source", "current")
+    request('http://localhost:8100/current.json', function (e, r, b) {
+      r.statusCode.should.eql(200)
+      var dynamicCurrent = JSON.parse(b)
+      dynamicCurrent.should.have.property("path")
+      dynamicCurrent.should.have.property("source", "current")
+      done()
+    })
+  })
+
+  it("should have index file that uses the layout", function(done){
+    fs.readFile(path.join(outputPath, "index.html"), function(err, contents){
+      contents.toString().should.include("Kitchen Sink")
+      contents.toString().should.include("Home")
+      request('http://localhost:8100/', function (e, r, b) {
+        r.statusCode.should.eql(200)
+        b.should.include("Kitchen Sink")
+        b.should.include("Home")
+        done()
+      })
+    })
+  })
+
+  it("should have custom 404 page that does not use layout", function(done){
+    fs.readFile(path.join(outputPath, "404.html"), function(err, contents){
+      contents.toString().should.not.include("Kitchen Sink")
+      contents.toString().should.include("Custom, Page Not Found")
+      request('http://localhost:8100/some/missing/path', function (e, r, b) {
+        r.statusCode.should.eql(404)
+        r.headers.should.have.property("content-type", "text/html; charset=UTF-8")
+        b.should.not.include("Kitchen Sink")
+        b.should.include("Custom, Page Not Found")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should return CSS file", function(done){
+    fs.readFile(path.join(outputPath, "css", "main.css"), function(err, contents){
+      contents.toString().should.include("background")
+      request('http://localhost:8100/css/main.css', function (e, r, b) {
+        r.statusCode.should.eql(200)
+        b.should.include("background")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should return proper mime type on 404 page", function(done){
+    request('http://localhost:8100/some/missing/path.css', function (e, r, b) {
+      r.statusCode.should.eql(404)
+      r.headers.should.have.property("content-type", "text/html; charset=UTF-8")
+      done()
+    })
+  })
+
+  it("should render HTML page without requiring extension", function(done){
+    fs.readFile(path.join(outputPath, "basic.html"), function(err, contents){
+      contents.toString().should.not.include("Kitchen Sink")
+      contents.toString().should.include("<h1>Basic HTML Page</h1>")
+      request('http://localhost:8100/basic', function(e,r,b){
+        r.statusCode.should.eql(200)
+        b.should.not.include("Kitchen Sink")
+        b.should.include("<h1>Basic HTML Page</h1>")
+        b.should.eql(contents.toString())
+        done()
+      })
+    })
+  })
+
+  it("should not return file starting with underscore", function(done){
+    request('http://localhost:8100/shared/_nav.jade', function(e,r,b){
+      r.statusCode.should.eql(404)
+      done()
+    })
+  })
+
+  it("should render HTML page with spaces in the file name", function(done){
+    request('http://localhost:8100/articles/with%20spaces', function(e,r,b){
+      r.statusCode.should.eql(200)
+      b.should.include("foo article")
+      done()
+    })
+  })
+
+  after(function(done){
+    exec("rm -rf " + outputPath, function(){
+      done()
+    })
+  })
+
+})

--- a/test/errors.js
+++ b/test/errors.js
@@ -36,10 +36,68 @@ describe("errors", function(){
     })
   })
 
+  describe("err-invalid-config-cson", function(){
+    var projectPath = path.join(__dirname, "apps/err-invalid-config-cson")
+    var outputPath  = path.join(__dirname, "out/err-invalid-config-cson")
+    var port        = 8112
+
+    before(function(done){
+      harp.server(projectPath, { port: port }, function(){
+        done()
+      })
+    })
+
+    it("should get error message for invalid harp.cson", function(done){
+      request('http://localhost:'+ port +'/', function (e, r, b) {
+        r.statusCode.should.eql(500)
+        b.should.include(harp.pkg.version)
+        harp.compile(projectPath, outputPath, function(error){
+          should.exist(error)
+          error.should.have.property("source")
+          error.should.have.property("dest")
+          error.should.have.property("filename")
+          error.should.have.property("message")
+          error.should.have.property("stack")
+          error.should.have.property("lineno")
+          done()
+        })
+      })
+    })
+  })
+
+  describe("err-invalid-config-hjson", function(){
+    var projectPath = path.join(__dirname, "apps/err-invalid-config-hjson")
+    var outputPath  = path.join(__dirname, "out/err-invalid-config-hjson")
+    var port        = 8113
+
+    before(function(done){
+      harp.server(projectPath, { port: port }, function(){
+        done()
+      })
+    })
+
+    it("should get error message for invalid harp.hjson", function(done){
+      request('http://localhost:'+ port +'/', function (e, r, b) {
+        r.statusCode.should.eql(500)
+        b.should.include(harp.pkg.version)
+        harp.compile(projectPath, outputPath, function(error){
+          should.exist(error)
+          error.should.have.property("source")
+          error.should.have.property("dest")
+          error.should.have.property("filename")
+          error.should.have.property("message")
+          error.should.have.property("stack")
+          error.should.have.property("lineno")
+          done()
+        })
+      })
+    })
+  })
+
   describe("err-invalid-data", function(){
     var projectPath = path.join(__dirname, "apps/err-invalid-data")
     var outputPath  = path.join(__dirname, "out/err-invalid-data")
-    var port        = 8112
+    var port        = 8121
 
     before(function(done){
       harp.server(projectPath, { port: port }, function(){
@@ -65,10 +123,68 @@ describe("errors", function(){
     })
   })
 
+  describe("err-invalid-data-cson", function(){
+    var projectPath = path.join(__dirname, "apps/err-invalid-data-cson")
+    var outputPath  = path.join(__dirname, "out/err-invalid-data-cson")
+    var port        = 8122
+
+    before(function(done){
+      harp.server(projectPath, { port: port }, function(){
+        done()
+      })
+    })
+
+    it("should get error message for invalid _data.cson", function(done){
+      request('http://localhost:'+ port +'/', function (e, r, b) {
+        r.statusCode.should.eql(500)
+        b.should.include(harp.pkg.version)
+        harp.compile(projectPath, outputPath, function(error){
+          should.exist(error)
+          error.should.have.property("source")
+          error.should.have.property("dest")
+          error.should.have.property("filename")
+          error.should.have.property("message")
+          error.should.have.property("stack")
+          error.should.have.property("lineno")
+          done()
+        })
+      })
+    })
+  })
+
+  describe("err-invalid-data-hjson", function(){
+    var projectPath = path.join(__dirname, "apps/err-invalid-data-hjson")
+    var outputPath  = path.join(__dirname, "out/err-invalid-data-hjson")
+    var port        = 8123
+
+    before(function(done){
+      harp.server(projectPath, { port: port }, function(){
+        done()
+      })
+    })
+
+    it("should get error message for invalid _data.hjson", function(done){
+      request('http://localhost:'+ port +'/', function (e, r, b) {
+        r.statusCode.should.eql(500)
+        b.should.include(harp.pkg.version)
+        harp.compile(projectPath, outputPath, function(error){
+          should.exist(error)
+          error.should.have.property("source")
+          error.should.have.property("dest")
+          error.should.have.property("filename")
+          error.should.have.property("message")
+          error.should.have.property("stack")
+          error.should.have.property("lineno")
+          done()
+        })
+      })
+    })
+  })
+
   describe("err-missing-public", function(){
     var projectPath = path.join(__dirname, "apps/err-missing-public")
     var outputPath  = path.join(__dirname, "out/err-missing-public")
-    var port        = 8113
+    var port        = 8131
 
     before(function(done){
       harp.server(projectPath, { port: port }, function(){
@@ -97,7 +213,7 @@ describe("errors", function(){
   describe("err-missing-public", function(){
     var projectPath = path.join(__dirname, "apps/err-missing-404")
     var outputPath  = path.join(__dirname, "out/err-missing-404")
-    var port        = 8114
+    var port        = 8141
 
     before(function(done){
       harp.server(projectPath, { port: port }, function(){

--- a/test/plain.js
+++ b/test/plain.js
@@ -17,7 +17,7 @@ describe("plain", function(){
     before(function(done){
       harp.compile(projectPath, outputPath, function(errors, output){
         config = output
-        harp.server(projectPath, { port: 8102 }, done)
+        harp.server(projectPath, { port: 8200 }, done)
       })
     })
 
@@ -28,7 +28,7 @@ describe("plain", function(){
 
     it("should serve index file", function(done){
       fs.readFile(path.join(outputPath, "index.html"), function(err, contents){
-        request('http://localhost:8102/', function(e, r, b){
+        request('http://localhost:8200/', function(e, r, b){
           r.statusCode.should.eql(200)
           b.should.eql(contents.toString())
           done()
@@ -39,7 +39,7 @@ describe("plain", function(){
     it("should serve text file", function(done){
       fs.readFile(path.join(outputPath, "hello.txt"), function(err, contents){
         contents.toString().should.eql("text files are wonderful")
-        request('http://localhost:8102/hello.txt', function(e, r, b){
+        request('http://localhost:8200/hello.txt', function(e, r, b){
           r.statusCode.should.eql(200)
           b.should.eql(contents.toString())
           done()
@@ -49,10 +49,10 @@ describe("plain", function(){
 
     it("should have custom 404 page that is raw HTML", function(done){
       fs.readFile(path.join(outputPath, "404.html"), function(err, contents){
-        request('http://localhost:8102/404.html', function(e, r, b){
+        request('http://localhost:8200/404.html', function(e, r, b){
           r.statusCode.should.eql(200)
           b.should.eql(contents.toString())
-          request('http://localhost:8102/missing/path', function(e, r, b){
+          request('http://localhost:8200/missing/path', function(e, r, b){
             r.statusCode.should.eql(404)
             b.should.eql(contents.toString())
             done()


### PR DESCRIPTION
(Related to terraform PR #102)

Finally, configuration & data files can be in Hjson or CSON format as well. It took some tinkering to keep supporting JSON templates. So, for now the file priority list looks like this: JSON, CSON, Hjson.

For converting data files, it depends on the modified terraform module, of course, but this version of Harp should still be able to run with an older version of terraform; some tests would fail, though.