### PR TITLE
Make the license more obvious per #104

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ app.use(harp.mount(__dirname + "/public"));
 
 
 ## License
-
 Copyright © 2012–2014 [Chloi Inc](http://chloi.io). All rights reserved.
+
+Harp is licensed under the [MIT license](http://opensource.org/licenses/MIT).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Without a LICENSE file, the only current declaration of the applicable license is in package.json. Being explicit in the readme will help people quickly understand what the license.