### PR TITLE
Allow 0 to be used as a port number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,8 @@ exports.server = function(dirPath, options, callback){
   app.use(middleware.poly)
   app.use(middleware.process)
   app.use(middleware.fallback)
-  app.listen(options.port || 9966, options.ip, callback)
+  if(typeof options.port == 'undefined') options.port = 9966;
+  app.listen(options.port, options.ip, callback)
 
   return app
 }
@@ -53,7 +54,8 @@ exports.multihost = function(dirPath, options, callback){
   app.use(middleware.poly)
   app.use(middleware.process)
   app.use(middleware.fallback)
-  app.listen(options.port || 9000, callback)
+  if(typeof options.port == 'undefined') options.port = 9000;
+  app.listen(options.port, callback)
 }
 
 /**


### PR DESCRIPTION
There's a valid use case for port 0 in node's [http](https://nodejs.org/api/all.html#all_server_listen_port_hostname_callback) module used by connect. That is:

> A port value of zero will assign a random port.

Unfortunately port 0 can't be used in Harp because of the `||` comparison, which evaluates 0 to false. This PR checks if the port is undefined instead, which will allow 0 to be used as an option.