### PR TITLE
Refactored CLI script to allow port 0

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -82,16 +82,12 @@ program
   .description("Start a Harp server in current directory")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
-    var ip          = program.ip || '0.0.0.0'
-    var port        = program.port || 9000
-    harp.server(projectPath, { ip: ip, port: port }, function(){
-      var address = ''
-      if(ip == '0.0.0.0' || ip == '127.0.0.1') {
-        address = 'localhost'
-      } else {
-        address = ip
-      }
-      var hostUrl = "http://" + address + ":" + port + "/"
+    if(typeof program.ip   == 'undefined') program.ip   = '0.0.0.0'
+    if(typeof program.port == 'undefined') program.port = 9000
+    harp.server(projectPath, { ip: program.ip, port: program.port }, function(){
+      var host = this.address()
+      if(host.address == '0.0.0.0' || host.address == '127.0.0.1') host.address = 'localhost'
+      var hostUrl = "http://" + host.address + ":" + host.port + "/"
       output("Your server is listening at " + hostUrl)
     })
   })
@@ -103,12 +99,13 @@ program
   .description("Start a Harp server to host a directory of Harp projects")
   .action(function(path, program){
     var projectPath = nodePath.resolve(process.cwd(), path || "")
-    var port        = program.port || 9000
-    harp.multihost(projectPath, { port: port }, function(){
-      if(port == "80"){
+    if(typeof program.port == 'undefined') program.port = 9000
+    harp.multihost(projectPath, { port: program.port }, function(){
+      var host = this.address()
+      if(host.port == "80"){
         var loc = "http://harp.nu"
       }else{
-        var loc = "http://harp.nu:" + port
+        var loc = "http://harp.nu:" + host.port
       }
       output("Your server is hosting multiple projects at " + loc)
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,8 @@ exports.multihost = function(dirPath, options, callback){
   app.use(middleware.process)
   app.use(middleware.fallback)
   app.listen(options.port || 9000, callback)
+
+  return app
 }
 
 /**


### PR DESCRIPTION
This supplements #503 but I wanted to include it separately since it contains more changes.

In this PR, Harp checks which values have been set by checking with `typeof mything == "undefined"` instead of `||`, so 0 can be allowed. It also changes the way the server address gets printed, using [server.address()](https://nodejs.org/api/all.html#all_server_address) to dynamically determine the port number _after_ the server has started.

I have tested with `harp server -p 0 .` but additional testing would be desired. I admit I don't really know what the multihost feature does and I did not test my code for that section, but it should work in theory. I also had the multihost function return the app because I thought I needed it at first, but on second thought I don't think it's required. Though, harp.server() returns the app, so shouldn't harp.multihost()? Let me know if there's a reason for it not being returned and I'll remove it.