### PR TITLE
fix content-length calculating

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ exports.pipeline = function(root){
       var charset    = mime.charsets.lookup(mimeType)
       rsp.statusCode = 200
       rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
-      rsp.setHeader('Content-Length', body.length)
+      rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
       rsp.end(body)
     })
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -167,7 +167,7 @@ var custom200static = function(req, rsp, next){
       var type    = helpers.mimeType("html")
       var charset = mime.charsets.lookup(type)
       rsp.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''))
-      rsp.setHeader('Content-Length', body.length)
+      rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
       rsp.statusCode = 200
       rsp.end(body)
     }else{
@@ -200,7 +200,7 @@ var custom200dynamic = function(req, rsp, next){
         var type    = helpers.mimeType("html")
         var charset = mime.charsets.lookup(type)
         rsp.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
-        rsp.setHeader('Content-Length', body.length);
+        rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
         rsp.statusCode = 200;
         rsp.end(body)
       }
@@ -226,7 +226,7 @@ var custom404static = function(req, rsp, next){
       var type    = helpers.mimeType("html")
       var charset = mime.charsets.lookup(type)
       rsp.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''))
-      rsp.setHeader('Content-Length', body.length)
+      rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
       rsp.statusCode = 404
       rsp.end(body)
     }else{
@@ -260,7 +260,7 @@ var custom404dynamic = function(req, rsp, next){
         var type    = helpers.mimeType("html")
         var charset = mime.charsets.lookup(type)
         rsp.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
-        rsp.setHeader('Content-Length', body.length);
+        rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
         rsp.statusCode = 404;
         rsp.end(body)
       }
@@ -287,7 +287,7 @@ var default404 = function(req, rsp, next){
     var charset = mime.charsets.lookup(type)
     rsp.setHeader('Content-Type', type + (charset ? '; charset=' + charset : ''));
     rsp.statusCode = 404
-    rsp.setHeader('Content-Length', body.length);
+    rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
     rsp.end(body)
   })
 }
@@ -512,7 +512,7 @@ exports.process = function(req, rsp, next){
           var body       = helpers.cssError(locals)
           rsp.statusCode = 200
           rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
-          rsp.setHeader('Content-Length', Buffer.byteLength(body, charset))
+          rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
           rsp.end(body)
         }else{
 
@@ -528,7 +528,7 @@ exports.process = function(req, rsp, next){
             var charset    = mime.charsets.lookup(mimeType)
             rsp.statusCode = 500
             rsp.setHeader('Content-Type', mimeType + (charset ? '; charset=' + charset : ''))
-            rsp.setHeader('Content-Length', Buffer.byteLength(body, charset))
+            rsp.setHeader('Content-Length', Buffer.byteLength(body, charset));
             rsp.end(body)
           })
         }


### PR DESCRIPTION
Some UTF-8 characters contain multiple bytes. Content-Length will be wrong if body has special characters such as Russian.
The better way would be to use this method for correct calculating.
https://nodejs.org/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding