### PR TITLE
Update to Terraform v1.0.0

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -50,7 +50,9 @@ exports.mimeType = function(source){
     return mime.lookup('html')
   }else if(['.less', '.styl', '.scss', '.sass'].indexOf(ext)  !== -1){
     return mime.lookup('css')
-  }else{
+  } else if (['.js', '.coffee'].indexOf(ext) !== -1) {
+    return mime.lookup('js')
+  } else {
     return mime.lookup(source)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ exports.compile = function(projectPath, outputPath, callback){
    */
   var copyFile = function(file, done){
     var ext = path.extname(file)
-    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".coffee"].indexOf(ext) === -1){
+    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".js", ".coffee"].indexOf(ext) === -1){
       var localPath = path.resolve(outputPath, file)
       fs.mkdirp(path.dirname(localPath), function(err){
         fs.copy(path.resolve(setup.publicPath, file), localPath, done)

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -315,10 +315,21 @@ exports.underscore = function(req, rsp, next){
  */
 exports.mwl = function(req, rsp, next){
   var ext = path.extname(req.url).replace(/^\./, '')
+  req.originalExt = ext
 
-  if(terraform.helpers.processors["html"].indexOf(ext) !== -1 || terraform.helpers.processors["css"].indexOf(ext) !== -1 || terraform.helpers.processors["js"].indexOf(ext) !== -1){
-    notFound(req, rsp, next)
-  }else{
+  // This prevents the source files from being served, but also
+  // has to factor in that in this brave new world, sometimes
+  // `.html` (Handlebars, others), `.css` (PostCSS), and
+  // `.js` (Browserify) are actually being used to specify
+  // source files
+
+  if (['html', 'css', 'js'].indexOf(ext) === -1) {
+    if (terraform.helpers.processors["html"].indexOf(ext) !== -1 || terraform.helpers.processors["css"].indexOf(ext) !== -1 || terraform.helpers.processors["js"].indexOf(ext) !== -1) {
+      notFound(req, rsp, next)
+    } else {
+      next()
+    }
+  } else {
     next()
   }
 }
@@ -333,7 +344,9 @@ exports.static = function(req, res, next) {
   var options  = {}
   var redirect = true
 
-  if ('GET' != req.method && 'HEAD' != req.method) return next();
+  if ('GET' != req.method && 'HEAD' != req.method) return next()
+  if (['html', 'css', 'js'].indexOf(path.extname(req.url).replace(/^\./, '')) !== -1) return next()
+
   var pathn = parse(req).pathname;
   var pause = utilsPause(req);
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -323,7 +323,7 @@ exports.mwl = function(req, rsp, next){
   // `.js` (Browserify) are actually being used to specify
   // source files
 
-  if (['html', 'css', 'js'].indexOf(ext) === -1) {
+  if (['js'].indexOf(ext) === -1) {
     if (terraform.helpers.processors["html"].indexOf(ext) !== -1 || terraform.helpers.processors["css"].indexOf(ext) !== -1 || terraform.helpers.processors["js"].indexOf(ext) !== -1) {
       notFound(req, rsp, next)
     } else {
@@ -345,7 +345,7 @@ exports.static = function(req, res, next) {
   var redirect = true
 
   if ('GET' != req.method && 'HEAD' != req.method) return next()
-  if (['html', 'css', 'js'].indexOf(path.extname(req.url).replace(/^\./, '')) !== -1) return next()
+  if (['js'].indexOf(path.extname(req.url).replace(/^\./, '')) !== -1) return next()
 
   var pathn = parse(req).pathname;
   var pause = utilsPause(req);


### PR DESCRIPTION
Terraform v1.0.0 isn’t tagged, and therefore the update isn’t actually committed yet. To run the tests, checkout this branch and then run:

```sh
npm install --save sintaxi/terraform#release-v1.0.0
```

We still have two failing tests, which might be coming from the `_data.js` update, or from how globals are handled in the latest version of Jade, which we updated to.

```sh
  88 passing (12s)
  2 failing

  1) basic should have global vars:
     SyntaxError: /Users/Kenneth/Sites/sintaxi/harp/test/out/basic/globals.json: Unexpected token <
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:450:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Context.<anonymous> (/Users/Kenneth/Sites/sintaxi/harp/test/basic.js:27:25)
    at Test.Runnable.run (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runnable.js:217:15)
    at Runner.runTest (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:373:10)
    at /Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:451:12
    at next (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:298:14)
    at /Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:308:7
    at next (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:246:23)
    at Immediate._onImmediate (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:275:5)
    at processImmediate [as _immediateCallback] (timers.js:383:17)


  2) basic should have current vars:
     SyntaxError: /Users/Kenneth/Sites/sintaxi/harp/test/out/basic/current.json: Unexpected token <
    at Object.parse (native)
    at Object.Module._extensions..json (module.js:450:27)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Context.<anonymous> (/Users/Kenneth/Sites/sintaxi/harp/test/basic.js:40:25)
    at Test.Runnable.run (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runnable.js:217:15)
    at Runner.runTest (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:373:10)
    at /Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:451:12
    at next (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:298:14)
    at /Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:308:7
    at next (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:246:23)
    at Immediate._onImmediate (/Users/Kenneth/Sites/sintaxi/harp/node_modules/mocha/lib/runner.js:275:5)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```