### PR TITLE
Fix harp so it can report the server address when using `server` command

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -84,8 +84,8 @@ program
     var projectPath = nodePath.resolve(process.cwd(), path || "")
     if(typeof program.ip   == 'undefined') program.ip   = '0.0.0.0'
     if(typeof program.port == 'undefined') program.port = 9000
-    harp.server(projectPath, { ip: program.ip, port: program.port }, function(){
-      var host = this.address()
+    var server = harp.server(projectPath, { ip: program.ip, port: program.port }, function(){
+      var host = server.address()
       if(host.address == '0.0.0.0' || host.address == '127.0.0.1') host.address = 'localhost'
       var hostUrl = "http://" + host.address + ":" + host.port + "/"
       output("Your server is listening at " + hostUrl)


### PR DESCRIPTION
I encountered the same problem that @howardroark did here: https://github.com/sintaxi/harp/commit/0b8e8c32230a76beeac0aac524279fb043bc554c

This fixes it so the harp CLI script uses the listener to figure out the listening address instead of `this`. I'm not sure if the multipart server is affected as it doesn't return the same thing in `lib/index.js`.
