### PR TITLE
Replace async.eachLimit with async.each to fix #538

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,11 +249,11 @@ exports.compile = function(projectPath, outputPath, callback){
     if(err) console.log(err)
 
     helpers.ls(setup.publicPath, function(err, results){
-      async.eachLimit(results, 72, compileFile, function(err){
+      async.each(results, compileFile, function(err){
         if(err){
           callback(err)
         }else{
-          async.eachLimit(results, 72, copyFile, function(err){
+          async.each(results, copyFile, function(err){
             setup.config['harp_version'] = pkg.version
             delete setup.config.globals
             callback(null, setup.config)


### PR DESCRIPTION
This PR replaces `async.eachLimit` with `async.each` to fix #538.