### PR TITLE
Fix missing .js files on compile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ exports.compile = function(projectPath, outputPath, callback){
    */
   var copyFile = function(file, done){
     var ext = path.extname(file)
-    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".js", ".coffee"].indexOf(ext) === -1){
+    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".coffee"].indexOf(ext) === -1){
       var localPath = path.resolve(outputPath, file)
       fs.mkdirp(path.dirname(localPath), function(err){
         fs.copy(path.resolve(setup.publicPath, file), localPath, done)

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -323,15 +323,15 @@ exports.mwl = function(req, rsp, next){
   // `.js` (Browserify) are actually being used to specify
   // source files
 
-  if (['js'].indexOf(ext) === -1) {
+  //if (['js'].indexOf(ext) === -1) {
     if (terraform.helpers.processors["html"].indexOf(ext) !== -1 || terraform.helpers.processors["css"].indexOf(ext) !== -1 || terraform.helpers.processors["js"].indexOf(ext) !== -1) {
       notFound(req, rsp, next)
     } else {
       next()
     }
-  } else {
-    next()
-  }
+  //} else {
+    //next()
+  //}
 }
 
 /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -345,7 +345,7 @@ exports.static = function(req, res, next) {
   var redirect = true
 
   if ('GET' != req.method && 'HEAD' != req.method) return next()
-  if (['js'].indexOf(path.extname(req.url).replace(/^\./, '')) !== -1) return next()
+  //if (['js'].indexOf(path.extname(req.url).replace(/^\./, '')) !== -1) return next()
 
   var pathn = parse(req).pathname;
   var pause = utilsPause(req);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parseurl": "1.3.0",
     "pause": "0.1.0",
     "send": "0.13.0",
-    "terraform": "1.1.0"
+    "terraform": "1.2.0"
   },
   "devDependencies": {
     "cheerio": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harp",
-  "version": "0.21.0",
+  "version": "0.21.0-pre.0",
   "description": "Static web server with built in preprocessing",
   "author": "Brock Whitten <brock@chloi.io>",
   "contributors":

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parseurl": "1.3.0",
     "pause": "0.1.0",
     "send": "0.13.0",
-    "terraform": "0.13.2"
+    "terraform": "1.1.0"
   },
   "devDependencies": {
     "cheerio": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harp",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "Static web server with built in preprocessing",
   "author": "Brock Whitten <brock@chloi.io>",
   "contributors":

--- a/test/apps/basic/public/shared/_debug.jade
+++ b/test/apps/basic/public/shared/_debug.jade
@@ -1,5 +1,5 @@
 h4 globals
-pre= JSON.stringify(locals, null, 2)
+pre= JSON.stringify(public, null, 2)
 
 h4 current
 pre= JSON.stringify(current, null, 2)

--- a/test/apps/basic/public/shared/_nav.jade
+++ b/test/apps/basic/public/shared/_nav.jade
@@ -7,3 +7,4 @@ ul
     a(href="/about") About
   li
     a(href="/feed.atom") RSS
+li= current.source

--- a/test/basic.js
+++ b/test/basic.js
@@ -39,12 +39,12 @@ describe("basic", function(){
   it("should have current vars", function(done){
     var staticCurrent = require(path.join(outputPath, "current.json"))
     staticCurrent.should.have.property("path")
-    staticCurrent.should.have.property("source", "current")
+    staticCurrent.should.have.property("source", "current.json")
     request('http://localhost:8100/current.json', function (e, r, b) {
       r.statusCode.should.eql(200)
       var dynamicCurrent = JSON.parse(b)
       dynamicCurrent.should.have.property("path")
-      dynamicCurrent.should.have.property("source", "current")
+      dynamicCurrent.should.have.property("source", "current.json")
       done()
     })
   })


### PR DESCRIPTION
Using `0.21.0-pre.0`, `js` files are not copied over on `harp compile` as they were in `0.20.3`. 

To be perfectly honest I do not fully understand why https://github.com/sintaxi/harp/pull/526 changed that file or how `harp` internally works, I just reverted this change on the `node_modules` my project uses and saw that the previous behaviour was restored.

See https://github.com/sintaxi/harp/issues/571#issuecomment-246149868 for a bit more context.