### PR TITLE
Only use 'localhost' replacement for 127.0.0.1

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -86,7 +86,7 @@ program
     var port        = program.port || 9000
     harp.server(projectPath, { ip: ip, port: port }, function(){
       var address = ''
-      if(ip == '0.0.0.0' || ip == '127.0.0.1') {
+      if(ip == '127.0.0.1') {
         address = 'localhost'
       } else {
         address = ip


### PR DESCRIPTION
As was discussed in issue #558, as Harp is now it is not possible
to distinguish between an instance listening on localhost and
any ip.  This change fixes that.
