### PR TITLE
Fix missing .js files on compile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ exports.compile = function(projectPath, outputPath, callback){
    */
   var copyFile = function(file, done){
     var ext = path.extname(file)
-    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".js", ".coffee"].indexOf(ext) === -1){
+    if(!terraform.helpers.shouldIgnore(file) && [".jade", ".ejs", ".md", ".styl", ".less", ".scss", ".sass", ".coffee"].indexOf(ext) === -1){
       var localPath = path.resolve(outputPath, file)
       fs.mkdirp(path.dirname(localPath), function(err){
         fs.copy(path.resolve(setup.publicPath, file), localPath, done)


### PR DESCRIPTION
Using `0.21.0-pre.0`, `js` files are not copied over on `harp compile` as they were in `0.20.3`. 

To be perfectly honest I do not fully understand why https://github.com/sintaxi/harp/pull/526 changed that file or how `harp` internally works, I just reverted this change on the `node_modules` my project uses and saw that the previous behaviour was restored.

See https://github.com/sintaxi/harp/issues/571#issuecomment-246149868 for a bit more context.