### PR TITLE
Bump dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parseurl": "1.3.0",
     "pause": "0.1.0",
     "send": "0.13.0",
-    "terraform": "0.13.2"
+    "terraform": "1.2.0"
   },
   "devDependencies": {
     "cheerio": "0.19.0",


### PR DESCRIPTION
It seems that version 3.4.2 of node-sass, which is a terraform dependency at version 0.13.2, is the cause of this [segmentation fault error](https://github.com/sass/node-sass/issues/1107) when used inside a gulp task such  as:

```
var bsGuide = require('browser-sync').create('Styleguide');

gulp.task('styleguide', function () {
        harp.server('../../styleguide', {
            port: 8000
        }, function () {
            bsGuide.init({
                port: 8001,
                proxy: 'localhost:8000',
                open: false,
                ui: false
            });

            gulp.watch([
                '../../styleguide/**/*.sass',
                '../../styleguide/**/*.scss'
            ], function () {
                bsGuide.reload();
            });

            gulp.watch(
                [
                    '../../styleguide/modules/**/*.jade',
                    '../../styleguide/modules/**/*.json',
                    '../../styleguide/*.md'
                ], function () {
                bsGuide.reload();
            });
        });
    });
```
