### PR TITLE
Update terraform@1.3.0's node-sass  dependency to 4.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "terraform": {
+      "version": "1.3.0",
+      "dependencies": {
+        "node-sass": {
+          "version": "4.1.1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I can now install harp on node 7.3.0. on windows, since node-sass 4.1.1 has a prebuilt binary for node 7.

Forced node-sass terraform dependency version to 4.1.1.