### PR TITLE
Add official dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:6-alpine
+ENTRYPOINT [ "harp" ]
+WORKDIR /app
+COPY . /opt/harp
+RUN npm install -g /opt/harp


### PR DESCRIPTION
After merging this, @sintaxi should be able to configure an automated build in the Docker Hub that builds one docker image tag per each git tag, allowing us to have a simple drop-in image where to mount the website code and get it working with no effort!

Thanks! Harp rocks! :guitar: 