### PR TITLE
fix optional parameters check in harp.compile() - second PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
+dist: trusty
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "4.2"
-  - "5.0"
+  - "6"
+  - "lts/*"

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ exports.compile = function(projectPath, outputPath, callback){
    * Both projectPath and outputPath are optional
    */
 
-  if(!callback){
+  if(!callback && typeof outputPath === "function"){
     callback   = outputPath
     outputPath = "www"
   }


### PR DESCRIPTION
Replacement for https://github.com/sintaxi/harp/pull/614 against the current master branch.

Note this was [tested](https://travis-ci.org/ccprog/harp/builds/444745298) on Travis CI against node.js v6 and v8; for that `.travis.yml` had to be adapted - it still mentioned v0.12 to v4. Tests against older versions failed, as package.json now sets a minimum version of v6.

(As long as we're on that matter, testing against v10 would currently not work because of https://github.com/sintaxi/harp/issues/637.)