### PR TITLE
Only use 'localhost' replacement for 127.0.0.1

### DIFF
--- a/bin/harp
+++ b/bin/harp
@@ -86,7 +86,7 @@ program
     var port        = program.port || 9000
     harp.server(projectPath, { ip: ip, port: port }, function(){
       var address = ''
-      if(ip == '0.0.0.0' || ip == '127.0.0.1') {
+      if(ip == '127.0.0.1') {
         address = 'localhost'
       } else {
         address = ip

--- a/test/harp.js
+++ b/test/harp.js
@@ -75,3 +75,22 @@ describe("harp init", function() {
   })
 
 })
+
+
+describe("harp server", function() {
+  it("displays localhost if listening on 127.0.0.1", function(done) {
+    this.timeout(10000);
+    nixt()
+      .stdout(/our server is listening at http:\/\/localhost:9000\//)
+      .run('node ./bin/harp server -i 127.0.0.1')
+      .end(done());
+  })
+
+  it('shows 0.0.0.0 by default', function(done) {
+    this.timeout(10000);
+    nixt()
+      .stdout(/our server is listening at http:\/\/0.0.0.0:9000\//)
+      .run('node ./bin/harp server')
+      .end(done());
+  })
+})


### PR DESCRIPTION
As was discussed in issue #558, as Harp is now it is not possible
to distinguish between an instance listening on localhost and
any ip.  This change fixes that.

Also adds tests to confirm behavior.