### PR TITLE
Fix basic auth

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -445,7 +445,7 @@ exports.basicAuth = function(req, res, next){
     res.setHeader('WWW-Authenticate', 'Basic realm="example"')
     res.end('Access denied')
   } else {
-    res.end('Access granted')
+    next();
   }
 
 


### PR DESCRIPTION
When Basic Auth is used, the server is simply returning "Access granted" to any request. Fixes #650 