### PR TITLE
fix: update to @dabh/colors for security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Jurgen Van de Moere <jurgen.van.de.moere@gmail.com>",
     "Marco Emrich <m.emrich@webmasters.de>",
     "Roger K <misterhtmlcss@gmail.com>",
-    "Claus Colloseus <ccprog@gmx.de>"
+    "Claus Colloseus <ccprog@gmx.de>",
+    "mannyluvstacos <mannyis@typingona.computer>"
   ],
   "keywords": [
     "static web server",
@@ -45,7 +46,7 @@
     "async": "0.2.9",
     "basic-auth": "^2.0.1",
     "boxt": "^1.0.0",
-    "colors": "^1.4.0",
+    "@dabh/colors": "^1.4.0",
     "connect": "^3.6.6",
     "envy-json": "0.2.1",
     "fs-extra": "1.x",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.